### PR TITLE
Set version number in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,8 @@ email = 'vpaliy97@gmail.com'
 author = 'Vasyl Paliy'
 requires_python = '>=2.7'
 license = 'MIT'
-version = None
+version = 1.0 # see merklelib/__init__.py
 
-
-with io.open(os.path.join(here, 'merklelib', '__init__.py'), encoding='utf-8') as fp:
-  version = re.compile(r".*__version__ = '(.*?)'", re.S).match(fp.read()).group(1)
 
 try:
   with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
# Issue 

The existing `setup.py` for uses a regex approach to derive the current version number from an `__init__.py` file. This causes installation failures when trying to call `setup.py` in Python3.10, which is likely due to some changes in how regex is supported between the various versions: 
```
$ pip install -e .
Obtaining file:///home/rwb/github/merklelib
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/rwb/github/merklelib/setup.py", line 25, in <module>
          version = re.compile(r".*__version__ = '(.*?)'", re.S).match(fp.read()).group(1)
      AttributeError: 'NoneType' object has no attribute 'group'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```
# Solution 

I would consider the existing approach a non-standard way of getting version numbers for a package, have have updated the `setup.py` file with the version number. I've also added a reference to the __init__.py file for posterity, and have not modified the version there. 

# Testing 
I've successfully installed using pip and a local clone:
```
$ pip install -e .
Obtaining file:///home/rwb/github/merklelib
  Preparing metadata (setup.py) ... done
Requirement already satisfied: six ...
Requirement already satisfied: future-fstrings ...
Requirement already satisfied: anytree ...
Installing collected packages: merklelib
  Attempting uninstall: merklelib
    Found existing installation: merklelib 1.0
    Uninstalling merklelib-1.0:
      Successfully uninstalled merklelib-1.0
  Running setup.py develop for merklelib
Successfully installed merklelib-1.0
```

I've also verified this fixes the original issue, which was using this in a setup.py script for DALiuGE: 
$ pip install -e . 
Obtaining file:///home/rwb/github/daliuge/daliuge-common
  Preparing metadata (setup.py) ... done
Collecting merklelib@ git+https://github.com/pritchardn/merklelib@update_setup_version#egg=merklelib
  Cloning https://github.com/pritchardn/merklelib (to revision update_setup_version) to /tmp/pip-install-wwha238a/merklelib_819970ce1fec4eb4a39989e6bc06704c
  Running command git clone --filter=blob:none --quiet https://github.com/pritchardn/merklelib /tmp/pip-install-wwha238a/merklelib_819970ce1fec4eb4a39989e6bc06704c
  Running command git checkout -b update_setup_version --track origin/update_setup_version
  Switched to a new branch 'update_setup_version'
  Branch 'update_setup_version' set up to track remote branch 'update_setup_version' from 'origin'.
  Resolved https://github.com/pritchardn/merklelib to commit 78465c4a7cca3fd53392af534bbc8fd85d40a4a5
  Preparing metadata (setup.py) ... done
